### PR TITLE
Feature/jwt

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,7 +21,16 @@ function App() {
         </Route>
         <Route path={`/${roomCode}`} render={({location}) => {
           const attemptedCode = location.pathname.substring(1);    // strip leading slash from path
-          const isHost = location.state ? location.state.isHost : false;
+          
+          let isHost = false;
+          
+          if (location.state) {
+            isHost = location.state.isHost;
+          } else if (localStorage.getItem(`room-${attemptedCode}`)) {
+            const roomDeets = JSON.parse(localStorage.getItem(`room-${attemptedCode}`));
+            isHost = roomDeets.roomClients[roomDeets.socketId].isHost;
+          }
+
           return (
             <RoomContainer
               roomCode={attemptedCode}

--- a/client/src/components/room/RoomContainer.js
+++ b/client/src/components/room/RoomContainer.js
@@ -1,15 +1,28 @@
 import { useState, useEffect } from 'react';
 import LobbyContainer from './lobby/LobbyContainer';
 import { generateNickname } from '../../utils/randomWords';
-import { initSocket } from '../../utils/socket-helper';
+import { initSocket, listenForJoinConfirmation } from '../../utils/socket-helper';
 
 const RoomContainer = ({roomCode, isHost}) => {
-  const [nickname] = useState(generateNickname());
+  const [nickname, setNickname] = useState(generateNickname());
+  const [, setSocketId] = useState(null);
   const [showLobby, setShowLobby] = useState(false);
 
   useEffect(() => {
-    // make initial connection to room
-    initSocket(roomCode, nickname, isHost);
+    if (!localStorage.getItem(`room-${roomCode}`)) {
+      // new client
+      // make initial connection to room
+      initSocket(roomCode, nickname, isHost);
+      listenForJoinConfirmation(roomCode, roomDeets => {
+        console.log('roomDeets: ', roomDeets);
+      });
+    } else {
+      // client already in room
+      const roomDeets = JSON.parse(localStorage.getItem(`room-${roomCode}`));
+      setSocketId(roomDeets.socketId);
+      setNickname(roomDeets.roomClients[roomDeets.socketId].nickname);
+    }
+
     setShowLobby(true);
   }, [roomCode, isHost, nickname]);
 

--- a/client/src/utils/socket-helper.js
+++ b/client/src/utils/socket-helper.js
@@ -34,7 +34,7 @@ export const listenForJoinConfirmation = (gameCode, next) => {
   socket.on('join-confirmation', roomDeets => {
     roomDeets["gameCode "] = gameCode;
     localStorage.setItem(`room-${gameCode}`, JSON.stringify(roomDeets));
-    debugger;
+
     next(roomDeets);
   });
 }

--- a/client/src/utils/socket-helper.js
+++ b/client/src/utils/socket-helper.js
@@ -28,6 +28,17 @@ export const initSocket = (gameCode, nickname, isHost) => {
   }
 };
 
+export const listenForJoinConfirmation = (gameCode, next) => {
+  if (!socket) return;
+
+  socket.on('join-confirmation', roomDeets => {
+    roomDeets["gameCode "] = gameCode;
+    localStorage.setItem(`room-${gameCode}`, JSON.stringify(roomDeets));
+    debugger;
+    next(roomDeets);
+  });
+}
+
 export const disconnectSocket = () => {
   if (socket) {
     socket.disconnect();

--- a/server/app.js
+++ b/server/app.js
@@ -17,8 +17,8 @@ io.on('connection', socket => {
   const socketRooms = io.sockets.adapter.rooms;
 
   socket.on('join', newConnection => {
-    const {gameCode} = newConnection;
-
+    const {gameCode, nickname, isHost} = newConnection;
+    
     socket.join(gameCode);
     const clientsInRoom = socketRooms.get(gameCode);
     
@@ -27,13 +27,18 @@ io.on('connection', socket => {
       allRooms[gameCode] = new Room(gameCode);
     }
     
-    const newClient = new Player(socket.id, newConnection.nickname);
+    const newClient = new Player(socket.id, nickname, isHost);
     allRooms[gameCode].addClient(newClient);
     
     // this gets an array of Player objects in the game
     //... i think this will be useful at some point (when adding a new player, return these to client?)
     const roomClients = allRooms[gameCode].clients;
-    console.log(`room ${gameCode}: `, roomClients);
+
+    // respond to client on "connected"
+    socket.emit("join-confirmation", {
+      socketId: socket.id,
+      roomClients
+    })
   })
 });
 

--- a/server/models/Player.js
+++ b/server/models/Player.js
@@ -1,7 +1,8 @@
 class Player {
-  constructor(socketId, nickname) {
+  constructor(socketId, nickname, isHost) {
     this.socketId = socketId;
     this.nickname = nickname;
+    this.isHost = isHost;
   }
 }
 


### PR DESCRIPTION
## What has been done

Allows a user to open a new tab and be recognised as the same user (does not add a new socket to room or generate a new nickname). A second user can join from e.g. an incognito window and be recognised as a new client. The app can recognise the user as a host if they open a new tab.

---

## How this has been achieved
Saves details about the room a client is connected to in `localstorage`. Details are saved in the following format:
```
{
    "socketId": "IbHtqRn7mU-0RRJ-AAAD",
    "roomClients": {
        "iQw48IIP3HSS3dUnAAAB": {
            "socketId": "iQw48IIP3HSS3dUnAAAB",
            "nickname": "CurlyQuerida",
            "isHost": true
        },
        "IbHtqRn7mU-0RRJ-AAAD": {
            "socketId": "IbHtqRn7mU-0RRJ-AAAD",
            "nickname": "IntegralCelestyna"
        }
   },
  "gameCode ": "simple-perfect"
}
```

In the above example, there is a room with code `simple-perfect` with two players (one standard session, one incognitosession): `CurlyQuerida` and `IntegradCelestyna`.

It's worth noting, at this stage, the above output was taken from the incognito session (second client) - there is no notifying the first client that a second client has been added...


.... _**not yet anyway 😎**_